### PR TITLE
Chapter Header Anchor Links

### DIFF
--- a/layouts/shortcodes/chapter_header.html
+++ b/layouts/shortcodes/chapter_header.html
@@ -1,1 +1,2 @@
-<h2 class="chapter-header" id="{{ .Get 1 }}">{{ .Get 0 }}</h2>
+<hr class="chapter-header-line"/>
+<h2 class="chapter-header" id="{{ .Get 1 }}">{{ .Get 0 }}{{ if .Site.Params.chapter_anchors.enabled }}<a href="#{{ .Get 1 }}"><i class="fa fa-link"></i></a>{{ end }}</h2>

--- a/static/css/customizations.css
+++ b/static/css/customizations.css
@@ -177,11 +177,30 @@ h3 {
   text-align: center;
 }
 
+#post-content hr.chapter-header-line {
+  border-top: 1px solid #f3f3f3;
+  margin-bottom: 0;
+  margin-top: 0;
+}
+
+#post-content h2.chapter-header a {
+  float: right;
+  font-size: 16px;
+}
+
 #post-content h2.chapter-header {
   text-align: center;
-  border-top: 1px solid #f3f3f3;
-  padding-top: 30px;
-  padding-bottom: 10px;
+  margin-top: 30px;
+  padding-bottom: 10px; 
+}
+
+#post-content h2.chapter-header::before {
+  display: block;
+  content: " ";
+  margin-top: -88px;
+  height: 88px;
+  visibility: hidden;
+  pointer-events: none;
 }
 
 /* Navbar */


### PR DESCRIPTION
When reading a blog post with sub headers it is useful to link to a specific section of the post. As such I have added the ability to enable (off by default) in config anchor link along side the chapter headers in a post. If enabled you will see a link icon which will have an anchor to that chapter heading.

In doing this feature, I have had to alter way the chapter headings are spaced using margins over padding. This allows us to use a hidden margin to push the anchor point to below the nav/menu bar.

**Config**
To enable this feature in `config.toml` add:
```toml
# Chapter Anchor Links
[params.chapter_anchors]
    enabled = true
```

**Results**
* Enabled:

![image](https://user-images.githubusercontent.com/30004860/55903246-1e818380-5bc5-11e9-8e2f-dc3922e5d98d.png)

* Disabled:
![image](https://user-images.githubusercontent.com/30004860/55903308-47a21400-5bc5-11e9-8cb8-1d127ccdc0fb.png)

* Mobile:
![image](https://user-images.githubusercontent.com/30004860/55903413-791adf80-5bc5-11e9-8988-09b6c959af0c.png)



Fixes #4 