### PR TITLE
Make footer more responsive and not partially covered on mobile devices

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,27 +1,31 @@
 <footer id="copyright">
   <div class="container">
     <div class="row">
-      <div class="col-md-4">
-        <ul class="info list-inline quicklinks pull-left">
+
+      <div class="col-xs-4">
+        <ul class="info list-inline pull-left">
           {{ range .Site.Params.footer.info }}
             <li>{{ .text  | markdownify }}</li>
           {{ end }}
         </ul>
       </div>
-      <div class="col-md-4">
-        <ul class="list-inline footer-social-buttons text-center">
+
+      <div class="col-xs-4 text-center">
+        <ul class="list-inline footer-social-buttons">
           {{ range .Site.Params.footer.social }}
             <li><a target="_blank" rel="noopener noreferrer" aria-label="social-media" href="{{ .link }}"><i class="fa {{ .icon }}"></i></a></li>
           {{ end }}
         </ul>
       </div>
-      <div class="col-md-4">
-        <ul class="info list-inline quicklinks pull-right">
+
+      <div class="col-xs-4">
+        <ul class="list-inline pull-right footer-links">
           {{ range .Site.Params.footer.quicklinks }}
             <li><a aria-label="quicklinks" href="{{ .link }}">{{ .text  | markdownify }}</a></li>
           {{ end }}
         </ul>
       </div>
+
     </div>
   </div>
 </footer>

--- a/layouts/partials/social/share_buttons.html
+++ b/layouts/partials/social/share_buttons.html
@@ -2,6 +2,7 @@
     {{ partial "social/_buttons.html" . }}
 </div>
 
+<!-- At 991px mobile social media layout is applied -->
 <div class="visible-xs visible-sm text-center">
     <div class="post-share post-share-fixed post-share-mobile">
         {{ partial "social/_buttons.html" . }}

--- a/static/css/bootstrap.default.css
+++ b/static/css/bootstrap.default.css
@@ -2638,26 +2638,6 @@ ul.footer-social-buttons {
 .info {
   margin-left: 15px;
 }
-#copyright {
-  background: #333;
-  color: #ccc;
-  padding: 15px 0;
-  font-size: 12px;
-  line-height: 28px;
-}
-#copyright p {
-  margin: 0;
-}
-#copyright a {
-  color: #eeeeee;
-}
-@media (max-width: 991px) {
-  #copyright p {
-    float: none !important;
-    text-align: center;
-    margin-bottom: 10px;
-  }
-}
 [data-animate] {
   opacity: 0;
   filter: alpha(opacity=0);

--- a/static/css/customizations.css
+++ b/static/css/customizations.css
@@ -434,3 +434,54 @@ a.facebook-button-follow:visited {
   background: #3B5998;
   text-decoration: none !important;
 }
+
+/* Site Footer */
+
+#copyright {
+  background: #333;
+  color: #ccc;
+  padding: 15px 0;
+  font-size: 12px;
+  line-height: 28px;
+}
+
+#copyright a {
+  color: #eeeeee;
+}
+
+#copyright .footer-social-buttons {
+  font-size: 20px;
+}
+
+@media (max-width: 768px) {
+  #copyright ul {
+    margin: 0;
+  }
+
+  #copyright .footer-social-buttons li {
+    font-size: 20px;
+    padding: 0;
+  }
+
+  #copyright .footer-links li {
+    display: list-item;
+    text-align: right;
+    margin-right: 0;
+  }
+}
+
+/*
+  The Social Media Buttons have a line height of 1.58 inherited from bootstrap.default.css body (ln 3198) and font-size of 20px
+
+  We can use just add a margin to the bottom of the footer whenever the screen meets the criteria of the social
+  media links going to the bottom of the webpage. The height of the buttons as appear on screen is ((1.58 * 20)) => 31.6px
+
+  The buttons also have 10px worth of padding we just add that will account for when the screen width is quite narrow and
+  the content in the footer wraps.
+*/
+
+@media (max-width: 991px) {
+  #copyright {
+    margin-bottom: 41.6px;
+  }
+}


### PR DESCRIPTION
There were scenarios in which social media buttons could partially cover the footer on mobile devices. This was down to the footer wrapping at the wrong screen widths and the footer not having enough of a margin for the floating social medial buttons to sit at the bottom of the page without covering the footer, see #6 for further info.

Fixes #6

## Testing

**Desktop**
Tested on Firefox and Safari in Desktop mode to verify that no adverse side effects have taken place to the footer.

**Mobile (ish)**
Tested on Firefox and Safari with mobile device emulation for several devices
_Pixel 2_ on Firefox
![Screenshot 2019-05-25 at 17 54 09](https://user-images.githubusercontent.com/30004860/58372543-d7eaad00-7f16-11e9-9d9e-8eb5def0fe23.png)
_Samsung S9_ on Firefox
![Screenshot 2019-05-25 at 17 54 20](https://user-images.githubusercontent.com/30004860/58372551-e9cc5000-7f16-11e9-92c5-3262aca98d17.png)
_iPhone SE_
![Screenshot 2019-05-25 at 17 54 43](https://user-images.githubusercontent.com/30004860/58372561-fcdf2000-7f16-11e9-8dcf-82b250559947.png)
_iPhone 8+_
![Screenshot 2019-05-25 at 17 56 03](https://user-images.githubusercontent.com/30004860/58372560-fcdf2000-7f16-11e9-9418-4452bff0469a.png)
_iPad_
![Screenshot 2019-05-25 at 17 58 21](https://user-images.githubusercontent.com/30004860/58372559-fcdf2000-7f16-11e9-8d25-8da99bb1e716.png)




_



